### PR TITLE
Fix line endings and encoding of accented characters

### DIFF
--- a/docs/site/publications/pubs.html
+++ b/docs/site/publications/pubs.html
@@ -1,1 +1,96 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"><html><head><title>TimeML Publications</title><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"><link href="../timeml.css" rel="stylesheet" type="text/css"></head><body><table width="100%" border="0" cellpadding="0" cellspacing="0">  <tr>    <td colspan="3" valign=top>      <table width="100%" height="50" border="0" cellpadding="5" cellspacing="0" class="banner">        <tr>          <td background="../images/banner.gif">&nbsp;</td>        </tr>      </table>    </td>  </tr>  <tr>    <td valign=top class="sidebar">      <p><a href="../index.html">TimeML</a></p>      <p>Publications</p>    <td valign=top width="5"><p>&nbsp;</p>        <p>&nbsp;</p>    </td>    <td valign=top class="mainText">      <h1>Publications</h1>      <h3>General</h3>      <p>Inderjeet Mani and James Pustejovsky. 2004. <a href="timeMLpubs/ACL04-Mani-Pusto.pdf">Temporal Discourse Models for Narrative Structure</a>.  <i>ACL 2004 Workshop on Discourse Annotation</i></p>      <p>James Pustejovsky, Jos&eacute; Castaño, Robert        Ingria, Roser Saurí, Robert Gaizauskas, Andrea Setzer and Graham Katz.        2003. <a href="timeMLpubs/IWCS-v4.pdf">TimeML: Robust Specification of Event and Temporal Expressions        in Text</a>. <i>IWCS-5, Fifth International Workshop on Computational Semantics.</i></p>      <p>James Pustejovsky and Rob Gaizauskas (editors) Forthcoming. <i>Reasoning        about Time and Events. </i>John Benjamins Publishers.</p>      <p>James Pustejovsky, Robert Knippen, Jessica Littman        and Roser Saurí. Forthcoming. <a href="timeMLpubs/PustejovskyEtAl2.pdf">Temporal and Event Information in Natural        language Text</a>. <i>Language Resources and Evaluation</i>.</p>      <p>James Pustejovsky, Roser Saurí, Jos&eacute; Castaño, Dragomir Radev,        Robert Gaizauskas, Andrea Setzer, Beth Sundheim and Graham Katz. 2004.        Representing Temporal and Event Knowledge for QA Systems. Mark T. Maybury        (ed.) <i>New Directions in Question Answering</i>. MIT Press, Cambridge.</p>      <p>James Pustejovsky and Janyce Wiebe. 2005. <a href="timeMLpubs/LRE-Introduction.pdf">Introduction to Special Issue of Advances in Question Answering</a>. <i>Language Resources and Evalueation.</i>      <p>Roser Saurí and Marc Verhagen. 2005. <a href="timeMLpubs/rsmv-TimeNet.pdf">Temporal          Information in Intensional Contexts</a>. Bunt, H., J. Geertzen and          E. Thijse (eds.) <i>IWCS-6. Sixth International Workshop on Computational      Semantics</i>: 404-406.</p>      <p>Marc Verhagen. 2004. <a href="timeMLpubs/timeslines.pdf">Times Between          the Lines</a>. Ph.D. thesis. Brandeis        University. Waltham, MA, USA.</p>      <p> Marc Verhagen. 2005. <a href="timeMLpubs/closure-chum.pdf">Temporal Closure in an Annotation Environment</a>. <i>Language Resources and Evaluation.</i><p>      <h3>Event and Time Tagging</h3>            <p>Roser Saurí, Robert Knippen, Marc        Verhagen and James Pustejovsky. 2005. <a href="timeMLpubs/evita-hlt05.pdf">Evita:        A Robust Event Recognizer for QA Systems</a><i>. Proceedings of HLT/EMNLP        2005:</i> 700-707.</p>      <p>Inderjeet Mani. 2005. <i>Time Expression Tagger and Normalizer. </i>http://complingone.georgetown.edu/linguist/GU_TIME        DOWNLOAD.HTML</p>      <p></p>      <h3>Event Anchoring and Ordering</h3>      <p>Inderjeet Mani and Barry Schiffman. Forthcoming. ’Temporally Anchoring        and Ordering Events in News’. James Pustejovsky and Robert Gaizauskas        (eds.) <i>Event Recognition in Natural Language</i>. John Benjamins.</p>      <p>Inderjeet Mani; Marc Verhagen; Ben Wellner; Chong          Min Lee and James Pustejovsky. 2006.<br>          <a href="timeMLpubs/ACL06-P06-1095.pdf">Machine Learning of Temporal        Relations</a>. ACL 2006. Sidney, Australia.</p>            <p>Inderjeet Mani, Ben Wellner, Marc Verhagen and James Pustejovsky. 2007. <a href="timeMLpubs/Brandeis-CS-07-268.pdf">Three        Approaches to Learning TLINKs in TimeML</a>. Technical Report CS-07-268.        Computer Science Department, Brandeis University. Waltham, USA.</p>      <h3>TimeBank</h3>      <p>James Pustejovsky, Patrick Hanks, Roser Saurí, Andrew          See, Robert Gaizauskas, Andrea Setzer, Dragomir Radev, Beth Sundheim,        David Day, Lisa Ferro and Marcia Lazo. 2003. The TIMEBANK Corpus. <i>Proceedings      of Corpus Linguistics 2003</i>: 647-656.</p>      <h3>Annotation and Annotation Tools</h3>      <p>Marc Verhagen, Inderjeet        Mani, Roser Saurí, Robert Knippen, Jess Littman and James Pustejovsky.        2005. <a href="timeMLpubs/tarsqi-acl05.pdf">Automating Temporal Annotation        with TARSQI</a>. Demo Session. <i>Proceedings        of the ACL 2005</i>.</p>      <p>James Pustejovsky, Martha Palmer and Adam            Meyers. 2005. Workshop on Frontiers in Corpus Annotation II. Pie        in the Sky. ACL 2005.</p>	<p>Marc Verhagen. 2005. <a href="timeMLpubs/tbox.pdf">Drawing TimeML Relations with T-BOX</a>.      	<p>Marc Verhagen and Robert Knippen. Forthcoming. TANGO:        A Graphical Annotation Environment for Ordering Relations. James Pustejovsky        and Robert Gaizauskas (eds.) <i>Time and Event Recognition in Natural      Language</i>. John Benjamin Publications.</p>      <p>&nbsp;</p>      <p>&nbsp;</p>      <p>&nbsp;</p>      <p>&nbsp;</p>      </td>  </tr></table></body></html>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>TimeML Publications</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link href="../timeml.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td colspan="3" valign=top>
+      <table width="100%" height="50" border="0" cellpadding="5" cellspacing="0" class="banner">
+        <tr>
+          <td background="../images/banner.gif">&nbsp;</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td valign=top class="sidebar">
+      <p><a href="../index.html">TimeML</a></p>
+      <p>Publications</p>
+    <td valign=top width="5"><p>&nbsp;</p>
+        <p>&nbsp;</p>
+    </td>
+    <td valign=top class="mainText">
+      <h1>Publications</h1>
+      <h3>General</h3>
+      <p>Inderjeet Mani and James Pustejovsky. 2004. <a href="timeMLpubs/ACL04-Mani-Pusto.pdf">Temporal Discourse Models for Narrative Structure</a>.  <i>ACL 2004 Workshop on Discourse Annotation</i></p>
+      <p>James Pustejovsky, JosÃ© CastaÃ±o, Robert
+        Ingria, Roser SaurÃ­, Robert Gaizauskas, Andrea Setzer and Graham Katz.
+        2003. <a href="timeMLpubs/IWCS-v4.pdf">TimeML: Robust Specification of Event and Temporal Expressions
+        in Text</a>. <i>IWCS-5, Fifth International Workshop on Computational Semantics.</i></p>
+      <p>James Pustejovsky and Rob Gaizauskas (editors) Forthcoming. <i>Reasoning
+        about Time and Events. </i>John Benjamins Publishers.</p>
+      <p>James Pustejovsky, Robert Knippen, Jessica Littman
+        and Roser SaurÃ­. Forthcoming. <a href="timeMLpubs/PustejovskyEtAl2.pdf">Temporal and Event Information in Natural
+        language Text</a>. <i>Language Resources and Evaluation</i>.</p>
+      <p>James Pustejovsky, Roser SaurÃ­, JosÃ© CastaÃ±o, Dragomir Radev,
+        Robert Gaizauskas, Andrea Setzer, Beth Sundheim and Graham Katz. 2004.
+        Representing Temporal and Event Knowledge for QA Systems. Mark T. Maybury
+        (ed.) <i>New Directions in Question Answering</i>. MIT Press, Cambridge.</p>
+      <p>James Pustejovsky and Janyce Wiebe. 2005. <a href="timeMLpubs/LRE-Introduction.pdf">Introduction to Special Issue of Advances in Question Answering</a>. <i>Language Resources and Evalueation.</i>
+      <p>Roser SaurÃ­ and Marc Verhagen. 2005. <a href="timeMLpubs/rsmv-TimeNet.pdf">Temporal
+          Information in Intensional Contexts</a>. Bunt, H., J. Geertzen and
+          E. Thijse (eds.) <i>IWCS-6. Sixth International Workshop on Computational
+      Semantics</i>: 404-406.</p>
+      <p>Marc Verhagen. 2004. <a href="timeMLpubs/timeslines.pdf">Times Between
+          the Lines</a>. Ph.D. thesis. Brandeis
+        University. Waltham, MA, USA.</p>
+      <p> Marc Verhagen. 2005. <a href="timeMLpubs/closure-chum.pdf">Temporal Closure in an Annotation Environment</a>. <i>Language Resources and Evaluation.</i><p>
+      <h3>Event and Time Tagging</h3>      
+      <p>Roser SaurÃ­, Robert Knippen, Marc
+        Verhagen and James Pustejovsky. 2005. <a href="timeMLpubs/evita-hlt05.pdf">Evita:
+        A Robust Event Recognizer for QA Systems</a><i>. Proceedings of HLT/EMNLP
+        2005:</i> 700-707.</p>
+      <p>Inderjeet Mani. 2005. <i>Time Expression Tagger and Normalizer. </i>http://complingone.georgetown.edu/linguist/GU_TIME
+        DOWNLOAD.HTML</p>
+      <p></p>
+      <h3>Event Anchoring and Ordering</h3>      <p>Inderjeet Mani and Barry Schiffman. Forthcoming. â€™Temporally Anchoring
+        and Ordering Events in Newsâ€™. James Pustejovsky and Robert Gaizauskas
+        (eds.) <i>Event Recognition in Natural Language</i>. John Benjamins.</p>
+      <p>Inderjeet Mani; Marc Verhagen; Ben Wellner; Chong
+          Min Lee and James Pustejovsky. 2006.<br>
+          <a href="timeMLpubs/ACL06-P06-1095.pdf">Machine Learning of Temporal
+        Relations</a>. ACL 2006. Sidney, Australia.</p>      
+      <p>Inderjeet Mani, Ben Wellner, Marc Verhagen and James Pustejovsky. 2007. <a href="timeMLpubs/Brandeis-CS-07-268.pdf">Three
+        Approaches to Learning TLINKs in TimeML</a>. Technical Report CS-07-268.
+        Computer Science Department, Brandeis University. Waltham, USA.</p>
+      <h3>TimeBank</h3>
+      <p>James Pustejovsky, Patrick Hanks, Roser SaurÃ­, Andrew
+          See, Robert Gaizauskas, Andrea Setzer, Dragomir Radev, Beth Sundheim,
+        David Day, Lisa Ferro and Marcia Lazo. 2003. The TIMEBANK Corpus. <i>Proceedings
+      of Corpus Linguistics 2003</i>: 647-656.</p>
+      <h3>Annotation and Annotation Tools</h3>      <p>Marc Verhagen, Inderjeet
+        Mani, Roser SaurÃ­, Robert Knippen, Jess Littman and James Pustejovsky.
+        2005. <a href="timeMLpubs/tarsqi-acl05.pdf">Automating Temporal Annotation
+        with TARSQI</a>. Demo Session. <i>Proceedings
+        of the ACL 2005</i>.</p>
+      <p>James Pustejovsky, Martha Palmer and Adam
+            Meyers. 2005. Workshop on Frontiers in Corpus Annotation II. Pie
+        in the Sky. ACL 2005.</p>
+	<p>Marc Verhagen. 2005. <a href="timeMLpubs/tbox.pdf">Drawing TimeML Relations with T-BOX</a>.      
+	<p>Marc Verhagen and Robert Knippen. Forthcoming. TANGO:
+        A Graphical Annotation Environment for Ordering Relations. James Pustejovsky
+        and Robert Gaizauskas (eds.) <i>Time and Event Recognition in Natural
+      Language</i>. John Benjamin Publications.</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>      <p>&nbsp;</p>
+      <p>&nbsp;</p>      </td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
The Github editor fixed up the line endings and said it transcoded from Windows 1252 codepage to UTF-8, and I updated the HTML charset in the header to match. Hopefully this will make the accented characters display correctly now. I also simplified the &eacute; entities to é.